### PR TITLE
Download-BLOB-and-ACI-Persisting-data-inVolume.

### DIFF
--- a/blobservice/Program.cs
+++ b/blobservice/Program.cs
@@ -8,7 +8,7 @@ namespace blobservice
         private static string _connection_string = "DefaultEndpointsProtocol=https;AccountName=appstore200089;AccountKey=SGnsTS1c1IT6cYeBWsNu3LYywQ/cYj9WtKWjudpUzRRNjIekbj1gx53thQQHZ6dDryuym2kQd3GKWmHs8rA9Og==;EndpointSuffix=core.windows.net";
         private static string _container_name = "data"; 
         private static string _blob_name = "Courses.json";
-        private static string _local_blob = "\\app\\Courses.json";
+        private static string _local_blob = "/app/data/Courses.json";
         static void Main(string[] args)
         {
             BlobServiceClient _service_client = new BlobServiceClient(_connection_string);
@@ -23,7 +23,7 @@ namespace blobservice
 
 
 /*
- 
+This C# Console based application will get the BLOB from storage account  
 You can see the volumes in your system from below path.
 \\wsl$\docker-desktop-data\version-pack-data\community\docker\volumes\blobvolume\_data
 


### PR DESCRIPTION
Purpose : Use the container instance to persist data onto a volume.

1. Dot net application is downloading a blob from a storage account. 
2. Create a image of that application deploy it to Azure container Registry.
3. Use this image in Azure Container instance to run a container in Azure Cloud.

	[As we already know that downloaded data in the container is not persistent. When container is deleted, then data will also get deleted. That's why we use volume]
	
4. Create a file share as your storage. Then container can mount a volume using This file share.

5. Now all the data can be stored in the file share itself.



